### PR TITLE
Add controls on source names for spe_pick and lc_pick

### DIFF
--- a/ddjemx.py
+++ b/ddjemx.py
@@ -570,7 +570,7 @@ class jemx_lcr(ddosa.DataAnalysis):
 
     cached=True
 
-    version="v1.3.6"
+    version="v1.3.5"
 
     def main(self):
         t1 = time.time()
@@ -1415,7 +1415,7 @@ class lc_pick(ddosa.DataAnalysis):
 
     cached=True
 
-    version="v1.3"
+    version="v1.3.5"
 
     def get_version(self):
         try:


### PR DESCRIPTION
In the list of sources, there are empty 'UNKNOWN'  '' (empty strings) or "NEW SOURCE".
The empty string causes all the sources to be collected in a unique file. This file has the source keyword of one source. 
This produces wrong results. It is necessary to remove them.
The lc_pick was looping on all science windows and all sources. It is necessary to optimize this.